### PR TITLE
Fix cve 2015 9284

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,8 @@ gem 'uglifier'
 gem 'puma'
 gem 'figaro'
 
+
+gem 'omniauth-rails_csrf_protection'
 gem 'omniauth-github'
 gem 'github_api'
 gem 'sidekiq'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,6 +177,9 @@ GEM
     omniauth-oauth2 (1.6.0)
       oauth2 (~> 1.1)
       omniauth (~> 1.9)
+    omniauth-rails_csrf_protection (0.1.2)
+      actionpack (>= 4.2)
+      omniauth (>= 1.3.1)
     pg (1.2.2)
     pry (0.12.2)
       coderay (~> 1.1.0)
@@ -320,6 +323,7 @@ DEPENDENCIES
   launchy
   newrelic_rpm
   omniauth-github
+  omniauth-rails_csrf_protection
   pg
   pry
   puma

--- a/app/views/shared/_navbar.html.haml
+++ b/app/views/shared/_navbar.html.haml
@@ -25,5 +25,5 @@
       - else
         %ul.nav.navbar-nav.navbar-right
           %li
-            =link_to 'Login with Github', login_path
+            =link_to 'Login with Github', login_path, method: :post
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
 
   get '/home',                    to: 'home#show'
-  get '/auth/github',             as: 'login'
+  post '/auth/github',            as: 'login'
   get '/auth/github/callback',    to: 'sessions#create'
   get '/logout',                  to: 'sessions#destroy'
   get '/auth/failure',            to: 'home#show'


### PR DESCRIPTION
This fixes the last Security flaw found by Github.

/auth/github - now uses POST and has Rails csrf protection from the installed gem